### PR TITLE
Use `hs.hotkey.modal` for modals, a bugfix, and some code cleanup

### DIFF
--- a/MiroWindowsManager.spoon/docs.json
+++ b/MiroWindowsManager.spoon/docs.json
@@ -15,13 +15,11 @@
         "stripped_doc" : [
           "The sizes that the window can have.  ",
           "The sizes are expressed as dividend of the entire screen's size.  ",
-          "For example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total",
-          "screen's size.  ",
-          "Ensuring that these numbers all divide both dimensions of",
-          "MiroWindowsManager.GRID to give integers makes everything work better."
+          "For example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total screen's size.  ",
+          "Make sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers."
         ],
+        "doc" : "The sizes that the window can have.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total screen's size.  \nMake sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.",
         "desc" : "The sizes that the window can have.",
-        "doc" : "The sizes that the window can have.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total\nscreen's size.  \nEnsuring that these numbers all divide both dimensions of\nMiroWindowsManager.GRID to give integers makes everything work better.",
         "notes" : [
 
         ],
@@ -40,15 +38,12 @@
         "stripped_doc" : [
           "The sizes that the window can have in full-screen.  ",
           "The sizes are expressed as dividend of the entire screen's size.  ",
-          "For example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4",
-          "and 1\/2 of the total screen's size.  ",
-          "Ensuring that these numbers all divide both dimensions of",
-          "MiroWindowsManager.GRID to give integers makes everything work better.  ",
-          "Special: Use 'c' for the original size and shape of the window before",
-          "starting to move it, but centered."
+          "For example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4 and 1\/2 of the total screen's size.  ",
+          "Make sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.",
+          "Use 'c' for the original size and shape of the window before starting to move it."
         ],
+        "doc" : "The sizes that the window can have in full-screen.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4 and 1\/2 of the total screen's size.  \nMake sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.\nUse 'c' for the original size and shape of the window before starting to move it.",
         "desc" : "The sizes that the window can have in full-screen.",
-        "doc" : "The sizes that the window can have in full-screen.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4\nand 1\/2 of the total screen's size.  \nEnsuring that these numbers all divide both dimensions of\nMiroWindowsManager.GRID to give integers makes everything work better.  \nSpecial: Use 'c' for the original size and shape of the window before\nstarting to move it, but centered.",
         "notes" : [
 
         ],
@@ -66,12 +61,11 @@
         "def" : "MiroWindowsManager.GRID",
         "stripped_doc" : [
           "The screen's grid size.  ",
-          "Ensuring that the numbers in MiroWindowsManager.sizes and",
-          "MiroWindowsManager.fullScreenSizes divide these numbers to give integers",
-          "makes everything work better."
+          "Make sure that the numbers in MiroWindowsManager.sizes and MiroWindowsManager.fullScreenSizes divide h and w to give",
+          "integers."
         ],
+        "doc" : "The screen's grid size.  \nMake sure that the numbers in MiroWindowsManager.sizes and MiroWindowsManager.fullScreenSizes divide h and w to give\nintegers.",
         "desc" : "The screen's grid size.",
-        "doc" : "The screen's grid size.  \nEnsuring that the numbers in MiroWindowsManager.sizes and\nMiroWindowsManager.fullScreenSizes divide these numbers to give integers\nmakes everything work better.",
         "notes" : [
 
         ],
@@ -86,22 +80,42 @@
         ]
       },
       {
-        "def" : "MiroWindowsManager.moveToNextScreen",
+        "def" : "MiroWindowsManager.pushToNextScreen",
         "stripped_doc" : [
-          "Boolean value to decide wether or not to move the window on the next screen",
-          "if the window is moved the screen edge."
+          "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge."
         ],
-        "desc" : "Boolean value to decide wether or not to move the window on the next screen",
-        "doc" : "Boolean value to decide wether or not to move the window on the next screen\nif the window is moved the screen edge.",
+        "doc" : "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge.",
+        "desc" : "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge.",
         "notes" : [
 
         ],
-        "signature" : "MiroWindowsManager.moveToNextScreen",
+        "signature" : "MiroWindowsManager.pushToNextScreen",
         "type" : "Variable",
         "returns" : [
 
         ],
-        "name" : "moveToNextScreen",
+        "name" : "pushToNextScreen",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "def" : "MiroWindowsManager.resizeRate",
+        "stripped_doc" : [
+          "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made",
+          "taller\/wider (or shorter\/thinner) in 5% increments."
+        ],
+        "doc" : "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made\ntaller\/wider (or shorter\/thinner) in 5% increments.",
+        "desc" : "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made",
+        "notes" : [
+
+        ],
+        "signature" : "MiroWindowsManager.resizeRate",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "resizeRate",
         "parameters" : [
 
         ]
@@ -114,13 +128,11 @@
 
     ],
     "type" : "Module",
-    "desc" : "With this Spoon you will be able to move the window in halves and in",
+    "desc" : "With this Spoon you will be able to move the window in halves and in corners using your keyboard and mainly using",
     "Constructor" : [
 
     ],
-    "Field" : [
-
-    ],
+    "doc" : "With this Spoon you will be able to move the window in halves and in corners using your keyboard and mainly using\narrows. You would also be able to resize them by thirds, quarters, or halves.  \nOfficial homepage for more info and documentation:\n[https:\/\/github.com\/miromannino\/miro-windows-manager](https:\/\/github.com\/miromannino\/miro-windows-manager)\n\nNOTE: This Spoon sets `hs.grid` globals with `hs.grid.setGrid()`, `hs.grid.MARGINX`, and `hs.grid.MARGINY`.\nChanging MiroWindowsManager.GRID will change these globals.\n\nDownload:\nhttps:\/\/github.com\/miromannino\/miro-windows-manager\/raw\/master\/MiroWindowsManager.spoon.zip",
     "Method" : [
       {
         "def" : "MiroWindowsManager:move(side)",
@@ -128,8 +140,8 @@
           "Move the frontmost window up, down, left, right.  ",
           ""
         ],
-        "desc" : "Move the frontmost window up, down, left, right.",
         "doc" : "Move the frontmost window up, down, left, right.  \n\nParameters:\n * side - 'up', 'down', 'left', or 'right'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Move the frontmost window up, down, left, right.",
         "notes" : [
 
         ],
@@ -145,13 +157,35 @@
         ]
       },
       {
-        "def" : "MiroWindowsManager:growFully(growth)",
+        "def" : "MiroWindowsManager:resize(growth)",
         "stripped_doc" : [
-          "Grow the frontmost window to full width \/ height taller, wider.  ",
+          "Resize the frontmost window taller, shorter, wider, or thinner.",
           ""
         ],
-        "desc" : "Grow the frontmost window to full width \/ height taller, wider.",
-        "doc" : "Grow the frontmost window to full width \/ height taller, wider.  \n\nParameters:\n * growth - 'taller', or 'wider'\n\nReturns:\n * The MiroWindowsManager object",
+        "doc" : "Resize the frontmost window taller, shorter, wider, or thinner.\n\nParameters:\n * growth - 'taller', 'shorter', 'wider', or 'thinner'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Resize the frontmost window taller, shorter, wider, or thinner.",
+        "notes" : [
+
+        ],
+        "signature" : "MiroWindowsManager:resize(growth)",
+        "type" : "Method",
+        "returns" : [
+          " * The MiroWindowsManager object"
+        ],
+        "name" : "resize",
+        "parameters" : [
+          " * growth - 'taller', 'shorter', 'wider', or 'thinner'",
+          ""
+        ]
+      },
+      {
+        "def" : "MiroWindowsManager:growFully(growth)",
+        "stripped_doc" : [
+          "Grow the frontmost window to full width \/ height.",
+          ""
+        ],
+        "doc" : "Grow the frontmost window to full width \/ height.\n\nParameters:\n * dimension - 'h', or 'w'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Grow the frontmost window to full width \/ height.",
         "notes" : [
 
         ],
@@ -162,7 +196,7 @@
         ],
         "name" : "growFully",
         "parameters" : [
-          " * growth - 'taller', or 'wider'",
+          " * dimension - 'h', or 'w'",
           ""
         ]
       },
@@ -173,8 +207,8 @@
           "Tap both directions to go full width \/ height.  ",
           ""
         ],
+        "doc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.  \nTap both directions to go full width \/ height.  \n\nParameters:\n * move - 'up', 'down', 'left', or 'right'\n\nReturns:\n * The MiroWindowsManager object",
         "desc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.",
-        "doc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.  \nTap both directions to go full width \/ height.  \n\nParameters:\n * move - 'up', 'down', 'left', 'right'\n\nReturns:\n * The MiroWindowsManager object",
         "notes" : [
 
         ],
@@ -185,7 +219,7 @@
         ],
         "name" : "go",
         "parameters" : [
-          " * move - 'up', 'down', 'left', 'right'",
+          " * move - 'up', 'down', 'left', or 'right'",
           ""
         ]
       },
@@ -195,8 +229,8 @@
           "Fullscreen, or cycle to next fullscreen option",
           ""
         ],
-        "desc" : "Fullscreen, or cycle to next fullscreen option",
         "doc" : "Fullscreen, or cycle to next fullscreen option\n\nParameters:\n * None.\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Fullscreen, or cycle to next fullscreen option",
         "notes" : [
 
         ],
@@ -217,8 +251,8 @@
           "Center",
           ""
         ],
-        "desc" : "Center",
         "doc" : "Center\n\nParameters:\n * None.\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Center",
         "notes" : [
 
         ],
@@ -239,8 +273,8 @@
           "Binds hotkeys for Miro's Windows Manager",
           ""
         ],
+        "doc" : "Binds hotkeys for Miro's Windows Manager\n\nParameters:\n * mapping - A table containing hotkey details for the following items:\n  * left: for the left action (usually `{hyper, \"left\"}`)\n  * right: for the right action (usually `{hyper, \"right\"}`)\n  * up: for the up action (usually {hyper, \"up\"})\n  * down: for the down action (usually `{hyper, \"down\"}`)\n  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)\n  * center: for the center action (e.g. `{hyper, \"c\"}`)\n  * move: for the move action (e.g. `{hyper, \"v\"}`). The move action is active as soon as the hotkey is pressed.\n      While active the left, right, up or down keys can be used (these are configured by the actions above). \n  * resize: for the resize action (e.g. `{hyper, \"d\"}`). The resize action is active as soon as the hotkey is\n      pressed. While active the left, right, up or down keys can be used (these are configured by the actions\n      above).\n\nA configuration example:\n``` lua\nlocal hyper = {\"ctrl\", \"alt\", \"cmd\"}\nspoon.MiroWindowsManager:bindHotkeys({\n  up          = {hyper, \"up\"},\n  down        = {hyper, \"down\"},\n  left        = {hyper, \"left\"},\n  right       = {hyper, \"right\"},\n  fullscreen  = {hyper, \"f\"},\n  center      = {hyper, \"c\"},\n  move        = {hyper, \"v\"},\n  resize      = {hyper, \"d\" }\n})\n```\n\nIn this example ctrl+alt+cmd+up will perform the 'up' action.\nPressing ctrl+alt+cmd+c the window will be centered.\nPressing ctrl+alt+cmd+f the window will be maximized.\nKeeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up, down, left, and right.\nKeeping ctrl+alt+cmd+d pressed you can resize the window using the arrow keys up, down, left, and right.",
         "desc" : "Binds hotkeys for Miro's Windows Manager",
-        "doc" : "Binds hotkeys for Miro's Windows Manager\n\nParameters:\n * mapping - A table containing hotkey details for the following items:\n  * left: for the left action (usually `{hyper, \"left\"}`)\n  * right: for the right action (usually `{hyper, \"right\"}`)\n  * up: for the up action (usually {hyper, \"up\"})\n  * down: for the down action (usually `{hyper, \"down\"}`)\n  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)\n\nA configuration example can be:\n``` lua\nlocal mods = {\"ctrl\", \"alt\", \"cmd\"}\nspoon.MiroWindowsManager:bindHotkeys({\n  up          = {mods, \"up\"},\n  down        = {mods, \"down\"},\n  left        = {mods, \"left\"},\n  right       = {mods, \"right\"},\n  fullscreen  = {mods, \"f\"},\n  center      = {mods, \"c\"},\n  move        = {mods, \"v\"},\n  resize      = {mods, \"d\"}\n})\n```",
         "notes" : [
 
         ],
@@ -257,30 +291,42 @@
           "  * up: for the up action (usually {hyper, \"up\"})",
           "  * down: for the down action (usually `{hyper, \"down\"}`)",
           "  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)",
+          "  * center: for the center action (e.g. `{hyper, \"c\"}`)",
+          "  * move: for the move action (e.g. `{hyper, \"v\"}`). The move action is active as soon as the hotkey is pressed.",
+          "      While active the left, right, up or down keys can be used (these are configured by the actions above). ",
+          "  * resize: for the resize action (e.g. `{hyper, \"d\"}`). The resize action is active as soon as the hotkey is",
+          "      pressed. While active the left, right, up or down keys can be used (these are configured by the actions",
+          "      above).",
           "",
-          "A configuration example can be:",
+          "A configuration example:",
           "``` lua",
-          "local mods = {\"ctrl\", \"alt\", \"cmd\"}",
+          "local hyper = {\"ctrl\", \"alt\", \"cmd\"}",
           "spoon.MiroWindowsManager:bindHotkeys({",
-          "  up          = {mods, \"up\"},",
-          "  down        = {mods, \"down\"},",
-          "  left        = {mods, \"left\"},",
-          "  right       = {mods, \"right\"},",
-          "  fullscreen  = {mods, \"f\"},",
-          "  center      = {mods, \"c\"},",
-          "  move        = {mods, \"v\"},",
-          "  resize      = {mods, \"d\"}",
+          "  up          = {hyper, \"up\"},",
+          "  down        = {hyper, \"down\"},",
+          "  left        = {hyper, \"left\"},",
+          "  right       = {hyper, \"right\"},",
+          "  fullscreen  = {hyper, \"f\"},",
+          "  center      = {hyper, \"c\"},",
+          "  move        = {hyper, \"v\"},",
+          "  resize      = {hyper, \"d\" }",
           "})",
-          "```"
+          "```",
+          "",
+          "In this example ctrl+alt+cmd+up will perform the 'up' action.",
+          "Pressing ctrl+alt+cmd+c the window will be centered.",
+          "Pressing ctrl+alt+cmd+f the window will be maximized.",
+          "Keeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up, down, left, and right.",
+          "Keeping ctrl+alt+cmd+d pressed you can resize the window using the arrow keys up, down, left, and right."
         ]
       },
       {
         "def" : "MiroWindowsManager:init()",
         "stripped_doc" : [
-
+          "Currently does nothing (implemented so that treating this Spoon like others won't cause errors)."
         ],
-        "desc" : "UNKNOWN DESC",
-        "doc" : "",
+        "doc" : "Currently does nothing (implemented so that treating this Spoon like others won't cause errors).",
+        "desc" : "Currently does nothing (implemented so that treating this Spoon like others won't cause errors).",
         "notes" : [
 
         ],
@@ -298,18 +344,16 @@
     "Command" : [
 
     ],
-    "doc" : "With this Spoon you will be able to move the window in halves and in\ncorners using your keyboard and mainly using arrows. You would also be able\nto resize them by thirds, quarters, or halves.  \nOfficial homepage for more info and documentation:\n[https:\/\/github.com\/miromannino\/miro-windows-manager](https:\/\/github.com\/miromannino\/miro-windows-manager)\n\nNOTE: This Spoon sets `hs.grid` globals with `hs.grid.setGrid()`,\n`hs.grid.MARGINX`, and `hs.grid.MARGINY`. Changing MiroWindowsManager.GRID\nwill change these globals.\n\nDownload:\nhttps:\/\/github.com\/miromannino\/miro-windows-manager\/raw\/master\/MiroWindowsManager.spoon.zip",
     "items" : [
       {
         "def" : "MiroWindowsManager.GRID",
         "stripped_doc" : [
           "The screen's grid size.  ",
-          "Ensuring that the numbers in MiroWindowsManager.sizes and",
-          "MiroWindowsManager.fullScreenSizes divide these numbers to give integers",
-          "makes everything work better."
+          "Make sure that the numbers in MiroWindowsManager.sizes and MiroWindowsManager.fullScreenSizes divide h and w to give",
+          "integers."
         ],
+        "doc" : "The screen's grid size.  \nMake sure that the numbers in MiroWindowsManager.sizes and MiroWindowsManager.fullScreenSizes divide h and w to give\nintegers.",
         "desc" : "The screen's grid size.",
-        "doc" : "The screen's grid size.  \nEnsuring that the numbers in MiroWindowsManager.sizes and\nMiroWindowsManager.fullScreenSizes divide these numbers to give integers\nmakes everything work better.",
         "notes" : [
 
         ],
@@ -328,15 +372,12 @@
         "stripped_doc" : [
           "The sizes that the window can have in full-screen.  ",
           "The sizes are expressed as dividend of the entire screen's size.  ",
-          "For example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4",
-          "and 1\/2 of the total screen's size.  ",
-          "Ensuring that these numbers all divide both dimensions of",
-          "MiroWindowsManager.GRID to give integers makes everything work better.  ",
-          "Special: Use 'c' for the original size and shape of the window before",
-          "starting to move it, but centered."
+          "For example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4 and 1\/2 of the total screen's size.  ",
+          "Make sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.",
+          "Use 'c' for the original size and shape of the window before starting to move it."
         ],
+        "doc" : "The sizes that the window can have in full-screen.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4 and 1\/2 of the total screen's size.  \nMake sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.\nUse 'c' for the original size and shape of the window before starting to move it.",
         "desc" : "The sizes that the window can have in full-screen.",
-        "doc" : "The sizes that the window can have in full-screen.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{1, 4\/3, 2}` means that it can be 1\/1 (hence full screen), 3\/4\nand 1\/2 of the total screen's size.  \nEnsuring that these numbers all divide both dimensions of\nMiroWindowsManager.GRID to give integers makes everything work better.  \nSpecial: Use 'c' for the original size and shape of the window before\nstarting to move it, but centered.",
         "notes" : [
 
         ],
@@ -351,22 +392,42 @@
         ]
       },
       {
-        "def" : "MiroWindowsManager.moveToNextScreen",
+        "def" : "MiroWindowsManager.pushToNextScreen",
         "stripped_doc" : [
-          "Boolean value to decide wether or not to move the window on the next screen",
-          "if the window is moved the screen edge."
+          "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge."
         ],
-        "desc" : "Boolean value to decide wether or not to move the window on the next screen",
-        "doc" : "Boolean value to decide wether or not to move the window on the next screen\nif the window is moved the screen edge.",
+        "doc" : "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge.",
+        "desc" : "Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge.",
         "notes" : [
 
         ],
-        "signature" : "MiroWindowsManager.moveToNextScreen",
+        "signature" : "MiroWindowsManager.pushToNextScreen",
         "type" : "Variable",
         "returns" : [
 
         ],
-        "name" : "moveToNextScreen",
+        "name" : "pushToNextScreen",
+        "parameters" : [
+
+        ]
+      },
+      {
+        "def" : "MiroWindowsManager.resizeRate",
+        "stripped_doc" : [
+          "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made",
+          "taller\/wider (or shorter\/thinner) in 5% increments."
+        ],
+        "doc" : "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made\ntaller\/wider (or shorter\/thinner) in 5% increments.",
+        "desc" : "Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made",
+        "notes" : [
+
+        ],
+        "signature" : "MiroWindowsManager.resizeRate",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "resizeRate",
         "parameters" : [
 
         ]
@@ -376,13 +437,11 @@
         "stripped_doc" : [
           "The sizes that the window can have.  ",
           "The sizes are expressed as dividend of the entire screen's size.  ",
-          "For example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total",
-          "screen's size.  ",
-          "Ensuring that these numbers all divide both dimensions of",
-          "MiroWindowsManager.GRID to give integers makes everything work better."
+          "For example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total screen's size.  ",
+          "Make sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers."
         ],
+        "doc" : "The sizes that the window can have.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total screen's size.  \nMake sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.",
         "desc" : "The sizes that the window can have.",
-        "doc" : "The sizes that the window can have.  \nThe sizes are expressed as dividend of the entire screen's size.  \nFor example `{2, 3, 3\/2}` means that it can be 1\/2, 1\/3 and 2\/3 of the total\nscreen's size.  \nEnsuring that these numbers all divide both dimensions of\nMiroWindowsManager.GRID to give integers makes everything work better.",
         "notes" : [
 
         ],
@@ -402,8 +461,8 @@
           "Binds hotkeys for Miro's Windows Manager",
           ""
         ],
+        "doc" : "Binds hotkeys for Miro's Windows Manager\n\nParameters:\n * mapping - A table containing hotkey details for the following items:\n  * left: for the left action (usually `{hyper, \"left\"}`)\n  * right: for the right action (usually `{hyper, \"right\"}`)\n  * up: for the up action (usually {hyper, \"up\"})\n  * down: for the down action (usually `{hyper, \"down\"}`)\n  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)\n  * center: for the center action (e.g. `{hyper, \"c\"}`)\n  * move: for the move action (e.g. `{hyper, \"v\"}`). The move action is active as soon as the hotkey is pressed.\n      While active the left, right, up or down keys can be used (these are configured by the actions above). \n  * resize: for the resize action (e.g. `{hyper, \"d\"}`). The resize action is active as soon as the hotkey is\n      pressed. While active the left, right, up or down keys can be used (these are configured by the actions\n      above).\n\nA configuration example:\n``` lua\nlocal hyper = {\"ctrl\", \"alt\", \"cmd\"}\nspoon.MiroWindowsManager:bindHotkeys({\n  up          = {hyper, \"up\"},\n  down        = {hyper, \"down\"},\n  left        = {hyper, \"left\"},\n  right       = {hyper, \"right\"},\n  fullscreen  = {hyper, \"f\"},\n  center      = {hyper, \"c\"},\n  move        = {hyper, \"v\"},\n  resize      = {hyper, \"d\" }\n})\n```\n\nIn this example ctrl+alt+cmd+up will perform the 'up' action.\nPressing ctrl+alt+cmd+c the window will be centered.\nPressing ctrl+alt+cmd+f the window will be maximized.\nKeeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up, down, left, and right.\nKeeping ctrl+alt+cmd+d pressed you can resize the window using the arrow keys up, down, left, and right.",
         "desc" : "Binds hotkeys for Miro's Windows Manager",
-        "doc" : "Binds hotkeys for Miro's Windows Manager\n\nParameters:\n * mapping - A table containing hotkey details for the following items:\n  * left: for the left action (usually `{hyper, \"left\"}`)\n  * right: for the right action (usually `{hyper, \"right\"}`)\n  * up: for the up action (usually {hyper, \"up\"})\n  * down: for the down action (usually `{hyper, \"down\"}`)\n  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)\n\nA configuration example can be:\n``` lua\nlocal mods = {\"ctrl\", \"alt\", \"cmd\"}\nspoon.MiroWindowsManager:bindHotkeys({\n  up          = {mods, \"up\"},\n  down        = {mods, \"down\"},\n  left        = {mods, \"left\"},\n  right       = {mods, \"right\"},\n  fullscreen  = {mods, \"f\"},\n  center      = {mods, \"c\"},\n  move        = {mods, \"v\"},\n  resize      = {mods, \"d\"}\n})\n```",
         "notes" : [
 
         ],
@@ -420,21 +479,33 @@
           "  * up: for the up action (usually {hyper, \"up\"})",
           "  * down: for the down action (usually `{hyper, \"down\"}`)",
           "  * fullscreen: for the full-screen action (e.g. `{hyper, \"f\"}`)",
+          "  * center: for the center action (e.g. `{hyper, \"c\"}`)",
+          "  * move: for the move action (e.g. `{hyper, \"v\"}`). The move action is active as soon as the hotkey is pressed.",
+          "      While active the left, right, up or down keys can be used (these are configured by the actions above). ",
+          "  * resize: for the resize action (e.g. `{hyper, \"d\"}`). The resize action is active as soon as the hotkey is",
+          "      pressed. While active the left, right, up or down keys can be used (these are configured by the actions",
+          "      above).",
           "",
-          "A configuration example can be:",
+          "A configuration example:",
           "``` lua",
-          "local mods = {\"ctrl\", \"alt\", \"cmd\"}",
+          "local hyper = {\"ctrl\", \"alt\", \"cmd\"}",
           "spoon.MiroWindowsManager:bindHotkeys({",
-          "  up          = {mods, \"up\"},",
-          "  down        = {mods, \"down\"},",
-          "  left        = {mods, \"left\"},",
-          "  right       = {mods, \"right\"},",
-          "  fullscreen  = {mods, \"f\"},",
-          "  center      = {mods, \"c\"},",
-          "  move        = {mods, \"v\"},",
-          "  resize      = {mods, \"d\"}",
+          "  up          = {hyper, \"up\"},",
+          "  down        = {hyper, \"down\"},",
+          "  left        = {hyper, \"left\"},",
+          "  right       = {hyper, \"right\"},",
+          "  fullscreen  = {hyper, \"f\"},",
+          "  center      = {hyper, \"c\"},",
+          "  move        = {hyper, \"v\"},",
+          "  resize      = {hyper, \"d\" }",
           "})",
-          "```"
+          "```",
+          "",
+          "In this example ctrl+alt+cmd+up will perform the 'up' action.",
+          "Pressing ctrl+alt+cmd+c the window will be centered.",
+          "Pressing ctrl+alt+cmd+f the window will be maximized.",
+          "Keeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up, down, left, and right.",
+          "Keeping ctrl+alt+cmd+d pressed you can resize the window using the arrow keys up, down, left, and right."
         ]
       },
       {
@@ -443,8 +514,8 @@
           "Center",
           ""
         ],
-        "desc" : "Center",
         "doc" : "Center\n\nParameters:\n * None.\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Center",
         "notes" : [
 
         ],
@@ -465,8 +536,8 @@
           "Fullscreen, or cycle to next fullscreen option",
           ""
         ],
-        "desc" : "Fullscreen, or cycle to next fullscreen option",
         "doc" : "Fullscreen, or cycle to next fullscreen option\n\nParameters:\n * None.\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Fullscreen, or cycle to next fullscreen option",
         "notes" : [
 
         ],
@@ -488,8 +559,8 @@
           "Tap both directions to go full width \/ height.  ",
           ""
         ],
+        "doc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.  \nTap both directions to go full width \/ height.  \n\nParameters:\n * move - 'up', 'down', 'left', or 'right'\n\nReturns:\n * The MiroWindowsManager object",
         "desc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.",
-        "doc" : "Move to screen edge, or cycle to next horizontal or vertical size if already there.  \nTap both directions to go full width \/ height.  \n\nParameters:\n * move - 'up', 'down', 'left', 'right'\n\nReturns:\n * The MiroWindowsManager object",
         "notes" : [
 
         ],
@@ -500,18 +571,18 @@
         ],
         "name" : "go",
         "parameters" : [
-          " * move - 'up', 'down', 'left', 'right'",
+          " * move - 'up', 'down', 'left', or 'right'",
           ""
         ]
       },
       {
         "def" : "MiroWindowsManager:growFully(growth)",
         "stripped_doc" : [
-          "Grow the frontmost window to full width \/ height taller, wider.  ",
+          "Grow the frontmost window to full width \/ height.",
           ""
         ],
-        "desc" : "Grow the frontmost window to full width \/ height taller, wider.",
-        "doc" : "Grow the frontmost window to full width \/ height taller, wider.  \n\nParameters:\n * growth - 'taller', or 'wider'\n\nReturns:\n * The MiroWindowsManager object",
+        "doc" : "Grow the frontmost window to full width \/ height.\n\nParameters:\n * dimension - 'h', or 'w'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Grow the frontmost window to full width \/ height.",
         "notes" : [
 
         ],
@@ -522,17 +593,17 @@
         ],
         "name" : "growFully",
         "parameters" : [
-          " * growth - 'taller', or 'wider'",
+          " * dimension - 'h', or 'w'",
           ""
         ]
       },
       {
         "def" : "MiroWindowsManager:init()",
         "stripped_doc" : [
-
+          "Currently does nothing (implemented so that treating this Spoon like others won't cause errors)."
         ],
-        "desc" : "UNKNOWN DESC",
-        "doc" : "",
+        "doc" : "Currently does nothing (implemented so that treating this Spoon like others won't cause errors).",
+        "desc" : "Currently does nothing (implemented so that treating this Spoon like others won't cause errors).",
         "notes" : [
 
         ],
@@ -552,8 +623,8 @@
           "Move the frontmost window up, down, left, right.  ",
           ""
         ],
-        "desc" : "Move the frontmost window up, down, left, right.",
         "doc" : "Move the frontmost window up, down, left, right.  \n\nParameters:\n * side - 'up', 'down', 'left', or 'right'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Move the frontmost window up, down, left, right.",
         "notes" : [
 
         ],
@@ -567,7 +638,32 @@
           " * side - 'up', 'down', 'left', or 'right'",
           ""
         ]
+      },
+      {
+        "def" : "MiroWindowsManager:resize(growth)",
+        "stripped_doc" : [
+          "Resize the frontmost window taller, shorter, wider, or thinner.",
+          ""
+        ],
+        "doc" : "Resize the frontmost window taller, shorter, wider, or thinner.\n\nParameters:\n * growth - 'taller', 'shorter', 'wider', or 'thinner'\n\nReturns:\n * The MiroWindowsManager object",
+        "desc" : "Resize the frontmost window taller, shorter, wider, or thinner.",
+        "notes" : [
+
+        ],
+        "signature" : "MiroWindowsManager:resize(growth)",
+        "type" : "Method",
+        "returns" : [
+          " * The MiroWindowsManager object"
+        ],
+        "name" : "resize",
+        "parameters" : [
+          " * growth - 'taller', 'shorter', 'wider', or 'thinner'",
+          ""
+        ]
       }
+    ],
+    "Field" : [
+
     ],
     "name" : "MiroWindowsManager"
   }

--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -215,8 +215,7 @@ function obj:resize(growth)
   fr[self._growthsRel[growth].dim] =
     fr[self._growthsRel[growth].dim] + (self._growthsRel[growth].growthSign * growthDiff)
 
-  if fr['y'] < 0 then fr['y'] = 0 end
-  if fr['x'] < 0 then fr['x'] = 0 end
+  fr = fr:intersect(frontmostScreen():frame())  -- avoid sizing out of bounds
 
   w:setFrame(fr)
   return self

--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -17,15 +17,13 @@
 
 --- === MiroWindowsManager ===
 ---
---- With this Spoon you will be able to move the window in halves and in
---- corners using your keyboard and mainly using arrows. You would also be able
---- to resize them by thirds, quarters, or halves.  
+--- With this Spoon you will be able to move the window in halves and in corners using your keyboard and mainly using
+--- arrows. You would also be able to resize them by thirds, quarters, or halves.  
 --- Official homepage for more info and documentation:
 --- [https://github.com/miromannino/miro-windows-manager](https://github.com/miromannino/miro-windows-manager)
 --- 
---- NOTE: This Spoon sets `hs.grid` globals with `hs.grid.setGrid()`,
---- `hs.grid.MARGINX`, and `hs.grid.MARGINY`. Changing MiroWindowsManager.GRID
---- will change these globals.
+--- NOTE: This Spoon sets `hs.grid` globals with `hs.grid.setGrid()`, `hs.grid.MARGINX`, and `hs.grid.MARGINY`.
+--- Changing MiroWindowsManager.GRID will change these globals.
 ---
 --- Download:
 --- https://github.com/miromannino/miro-windows-manager/raw/master/MiroWindowsManager.spoon.zip
@@ -63,24 +61,22 @@ obj.sizes = {2, 3, 3/2}
 --- Variable
 --- The sizes that the window can have in full-screen.  
 --- The sizes are expressed as dividend of the entire screen's size.  
---- For example `{1, 4/3, 2}` means that it can be 1/1 (hence full screen), 3/4
---- and 1/2 of the total screen's size.  
+--- For example `{1, 4/3, 2}` means that it can be 1/1 (hence full screen), 3/4 and 1/2 of the total screen's size.  
 --- Make sure that these numbers divide both dimensions of MiroWindowsManager.GRID to give integers.
 --- Use 'c' for the original size and shape of the window before starting to move it.
 obj.fullScreenSizes = {1, 2, 'c'}
 
--- Comment: Lots of work here to save users a little work. Previous versions
--- required users to call MiroWindowsManager:start() every time they changed
--- GRID. The metatable work here watches for those changes and does the work
--- :start() would have done.
+-- Comment: Lots of work here to save users a little work. Previous versions required users to call
+-- MiroWindowsManager:start() every time they changed GRID. The metatable work here watches for those changes and does
+-- the work :start() would have done.
 package.path = package.path..";Spoons/".. ... ..".spoon/?.lua"
 require('extend_GRID').extend(obj, logger)
 
 --- MiroWindowsManager.GRID
 --- Variable
 --- The screen's grid size.  
---- Ensuring that the numbers in MiroWindowsManager.sizes and
---- Make sure that the numbers in MiroWindowsManager.fullScreenSizes divide h and w to give integers.
+--- Make sure that the numbers in MiroWindowsManager.sizes and MiroWindowsManager.fullScreenSizes divide h and w to give
+--- integers.
 obj.GRID = { w = 24, h = 24, margins = hs.geometry.point(0,0) }
 function obj.GRID.cell()
   return hs.geometry(obj.GRID.margins, hs.geometry.size(obj.GRID.w, obj.GRID.h))
@@ -89,15 +85,14 @@ end
 
 --- MiroWindowsManager.pushToNextScreen
 --- Variable
---- Boolean value to decide wether or not to move the window on the next screen
---- if the window is moved the screen edge.
+--- Boolean value to decide wether or not to move the window on the next screen if the window is moved the screen edge.
 obj.pushToNextScreen = false
 
 
 --- MiroWindowsManager.resizeRate
 --- Variable
---- Float value to decide the the rate to resize windows. With a value of 1.05 it means that 
---- everytime the window is made taller/wider by 5% more (or shorter/thinner by 5% less)
+--- Float value to decide the rate at which to resize windows. A value of 1.05 means that the window is made
+--- taller/wider (or shorter/thinner) in 5% increments.
 obj.resizeRate = 1.05
 
 -- ## Internal
@@ -117,7 +112,7 @@ obj._growthsRel = {
   thinner = { opp = 'wider',   dim = 'w', pos = 'x', growthSign = -1 },
 }
 
--- The keys used to move, generally the arrow keys, but they could also be WASD or something else
+-- The keys used to move, generally the arrow keys, but they could also be WASD or something else.
 obj._movingKeys = { }
 for _,move in ipairs(obj._directions) do
   obj._movingKeys[move] = move
@@ -152,11 +147,11 @@ end
 
 -- ### Utilities
 
-function titleCase(str)
+local function titleCase(str)
   return (str:gsub('^%l', string.upper))
 end
 
-function round(num)
+local function round(num)
   if num >= 0 then
     return math.floor(num+.499999999)
   else
@@ -164,16 +159,16 @@ function round(num)
   end
 end
 
--- Accessor for functions on the frontmost window
-function frontmostWindow()
+-- Accessor for functions on the frontmost window.
+local function frontmostWindow()
   return hs.window.frontmostWindow()
 end
 
-function frontmostScreen()
+local function frontmostScreen()
   return frontmostWindow():screen()
 end
 
-function frontmostCell()
+local function frontmostCell()
   local win = frontmostWindow()
   return hs.grid.get(win, win:screen())
 end
@@ -227,10 +222,10 @@ end
 
 --- MiroWindowsManager:resize(growth)
 --- Method
---- Resize the frontmost window taller, shorter, wider, thinner.
+--- Resize the frontmost window taller, shorter, wider, or thinner.
 ---
 --- Parameters:
----  * growth - 'taller', 'shorter', 'wider', 'thinner'
+---  * growth - 'taller', 'shorter', 'wider', or 'thinner'
 ---
 --- Returns:
 ---  * The MiroWindowsManager object
@@ -240,9 +235,11 @@ function obj:resize(growth)
   local w = frontmostWindow()
   local fr = w:frame()
 
-  local growthDiff = fr[self._growthsRel[growth].dim] * (self.resizeRate - 1) 
-  fr[self._growthsRel[growth].pos] = fr[self._growthsRel[growth].pos] - (self._growthsRel[growth].growthSign * growthDiff / 2)
-  fr[self._growthsRel[growth].dim] = fr[self._growthsRel[growth].dim] + (self._growthsRel[growth].growthSign * growthDiff)
+  local growthDiff = fr[self._growthsRel[growth].dim] * (self.resizeRate - 1)
+  fr[self._growthsRel[growth].pos] =
+    fr[self._growthsRel[growth].pos] - (self._growthsRel[growth].growthSign * growthDiff / 2)
+  fr[self._growthsRel[growth].dim] =
+    fr[self._growthsRel[growth].dim] + (self._growthsRel[growth].growthSign * growthDiff)
 
   if fr['y'] < 0 then fr['y'] = 0 end
   if fr['x'] < 0 then fr['x'] = 0 end
@@ -300,16 +297,16 @@ end
 --- Tap both directions to go full width / height.  
 ---
 --- Parameters:
----  * move - 'up', 'down', 'left', 'right'
+---  * move - 'up', 'down', 'left', or 'right'
 ---
 --- Returns:
 ---  * The MiroWindowsManager object
 function obj:go(move)
   registerPress(move)
   if currentlyPressed(self._directionsRel[move].opp) then
-    -- if still keydown moving the in the opposite direction, go full width/height
-    logger.i("Maximising " .. self._directionsRel[move].dim .. " since " 
-      .. self._directionsRel[move].opp .." still active.")
+    -- if still keydown moving in the opposite direction, go full width/height
+    logger.i("Maximising " .. self._directionsRel[move].dim .. " since " .. self._directionsRel[move].opp ..
+             " still active.")
     self:growFully(self._directionsRel[move].dim) -- full width/height
   else
     local cell = frontmostCell()
@@ -340,17 +337,19 @@ function obj:fullscreen()
 
   if seq == 0 then
     if hs.fnutils.contains(self.fullScreenSizes, 'c') then
-      logger.i("Since we are at seq 0, storing current position to use it with 'c' for window " .. frontmostWindow():id())
+      logger.i("Since we are at seq 0, storing current position to use it with 'c' for window " ..
+               frontmostWindow():id())
       self._originalPositionStore['fullscreen'][frontmostWindow():id()] = frontmostCell()
     end
   end
 
-  seq = seq % #self.fullScreenSizes + 1  -- if seq = #self.fullScreenSizes then 0 so next seq = 1 (we cycle through sizes)
+  -- if seq = #self.fullScreenSizes then 0 so next seq = 1 (we cycle through sizes)
+  seq = seq % #self.fullScreenSizes + 1
   logger.i("Updating seq to " .. tostring(seq) .." (size: ".. tostring(self.fullScreenSizes[seq]) ..")")
 
   if self.fullScreenSizes[seq] == 'c' then
     logger.i("Seq is 'c' but we don't have a saved position, skip to the next one")
-    if not self._originalPositionStore['fullscreen'][frontmostWindow():id()] then 
+    if not self._originalPositionStore['fullscreen'][frontmostWindow():id()] then
       seq = seq % #self.fullScreenSizes + 1
     end
   end
@@ -384,12 +383,11 @@ function obj:currentSeq(side)
     local width = frontmostCell()[dim]
     local relative_size = self.GRID[dim] / width
 
-    -- TODO
     local lastMatchedSeq =
       self._lastSeq[side] and  -- we've recorded a last seq, and
       self.sizes[self._lastSeq[side]] and  -- it's a valid index to sizes
       self._lastSeq[side]
-      local lastMatchedSeqMatchesFrontmost =
+    local lastMatchedSeqMatchesFrontmost =
       lastMatchedSeq and (self.sizes[lastMatchedSeq] == relative_size)
 
     -- cleanup
@@ -432,22 +430,21 @@ function obj:currentlyBound(side)
   local cell = frontmostCell()
   if side == 'up' then
     return cell.y == 0
-    elseif side == 'down' then
-      return cell.y + cell.h == self.GRID.h
-      elseif side == 'left' then
-        return cell.x == 0
-        elseif side == 'right' then
-          return cell.x + cell.w == self.GRID.w
-        end
-      end
+  elseif side == 'down' then
+    return cell.y + cell.h == self.GRID.h
+  elseif side == 'left' then
+    return cell.x == 0
+  elseif side == 'right' then
+    return cell.x + cell.w == self.GRID.w
+  end
+end
 
 -- ### Fullscreen methods
 
 -- Query whether window is centered
 function obj:currentlyCentered()
   local cell = frontmostCell()
-  return cell.w + 2 * cell.x == self.GRID.w and
-  cell.h + 2 * cell.y == self.GRID.h
+  return cell.w + 2 * cell.x == self.GRID.w and cell.h + 2 * cell.y == self.GRID.h
 end
 
 function obj:snap_to_grid(cell)
@@ -464,8 +461,8 @@ function obj:currentFullscreenSeq()
       self.fullScreenSizes[self._lastFullscreenSeq] and -- it's (still) a valid index to fullScreenSizes
       cell == self:getFullscreenCell(self._lastFullscreenSeq) then -- last matched seq is same as the current fullscreen
     logger.i('last matched seq is same as current cell, so returning seq = ' .. tostring(self._lastFullscreenSeq))
-    return self._lastFullscreenSeq 
-  else 
+    return self._lastFullscreenSeq
+  else
     self._lastFullscreenSeq = nil -- cleanup if the last matched seq doesn't match the frontmost
   end
 
@@ -478,20 +475,18 @@ function obj:currentFullscreenSeq()
     end
   end
 
-  -- we cannot find any fullscreen size that match the current window state, so we start with 0
+  -- we cannot find any fullscreen size that matches the current window state, so we start with 0
   return 0
 
 end
 
 -- Set fullscreen sequence
 function obj:setToFullscreenSeq(seq)
-  logger.i('lastMatchedSeq: ' .. tostring(lastMatchedSeq))
-
   self._setPosition(self:getFullscreenCell(seq))
 
   if self.fullScreenSizes[seq] == 'c' then
-    -- we want to use the value only once and then discarge
-    -- this is in case the window was in one of the full screen position/size
+    -- we want to use the value only once and then discard it
+    -- this is in case the window was in one of the full screen positions/sizes
     self._originalPositionStore['fullscreen'][frontmostWindow():id()] = nil
   end
 
@@ -546,12 +541,13 @@ obj.hotkeys = {}
 ---   * down: for the down action (usually `{hyper, "down"}`)
 ---   * fullscreen: for the full-screen action (e.g. `{hyper, "f"}`)
 ---   * center: for the center action (e.g. `{hyper, "c"}`)
----   * move: for the move action (e.g. `{hyper, "v"}`). The move action is
----           active as soon as the hotkey is pressed. While active the left, 
----           right, up or down keys can be used (these are configured by 
----           the actions above). 
+---   * move: for the move action (e.g. `{hyper, "v"}`). The move action is active as soon as the hotkey is pressed.
+---       While active the left, right, up or down keys can be used (these are configured by the actions above). 
+---   * resize: for the resize action (e.g. `{hyper, "d"}`). The resize action is active as soon as the hotkey is
+---       pressed. While active the left, right, up or down keys can be used (these are configured by the actions
+---       above).
 ---
---- A configuration example can be:
+--- A configuration example:
 --- ``` lua
 --- local hyper = {"ctrl", "alt", "cmd"}
 --- spoon.MiroWindowsManager:bindHotkeys({
@@ -561,20 +557,23 @@ obj.hotkeys = {}
 ---   right       = {hyper, "right"},
 ---   fullscreen  = {hyper, "f"},
 ---   center      = {hyper, "c"},
----   move        = {hyper, "v"}
+---   move        = {hyper, "v"},
+---   resize      = {hyper, "d" }
 --- })
----
---- In this example ctrl+alt+cmd+up will perform the 'up' action
---- Keeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up,down,left, and right
---- Pressing ctrl+alt+cmd+f the window will be maximized.
 --- ```
+---
+--- In this example ctrl+alt+cmd+up will perform the 'up' action.
+--- Pressing ctrl+alt+cmd+c the window will be centered.
+--- Pressing ctrl+alt+cmd+f the window will be maximized.
+--- Keeping ctrl+alt+cmd+v pressed you can move the window using the arrow keys up, down, left, and right.
+--- Keeping ctrl+alt+cmd+d pressed you can resize the window using the arrow keys up, down, left, and right.
 function obj:bindHotkeys(mapping)
   logger.i("Bind Hotkeys for Miro's Windows Manager")
 
   for _,direction in ipairs(self._directions) do
     if mapping[direction] then
       self.hotkeys[#self.hotkeys + 1] = hs.hotkey.bind(
-        mapping[direction][1], 
+        mapping[direction][1],
         mapping[direction][2],
         function() self:go(direction) end,
         function() cancelPress(direction) end)
@@ -587,38 +586,38 @@ function obj:bindHotkeys(mapping)
 
     if mapping.fullscreen then
       self.hotkeys[#self.hotkeys + 1] = hs.hotkey.bind(
-        mapping.fullscreen[1], 
+        mapping.fullscreen[1],
         mapping.fullscreen[2],
         function() self:fullscreen() end)
     end
 
     if mapping.center then
       self.hotkeys[#self.hotkeys + 1] = hs.hotkey.bind(
-        mapping.center[1], 
+        mapping.center[1],
         mapping.center[2],
         function() self:center() end)
     end
 
     if mapping.move then
       self.hotkeys[#self.hotkeys + 1] = hs.hotkey.bind(
-        mapping.move[1], 
-        mapping.move[2], 
-        function() self:_moveModeOn() end, 
+        mapping.move[1],
+        mapping.move[2],
+        function() self:_moveModeOn() end,
         function() self:_moveModeOff() end)
     end
 
     if mapping.resize then
       self.hotkeys[#self.hotkeys + 1] = hs.hotkey.bind(
-        mapping.resize[1], 
-        mapping.resize[2], 
-        function() self:_resizeModeOn() end, 
+        mapping.resize[1],
+        mapping.resize[2],
+        function() self:_resizeModeOn() end,
         function() self:_resizeModeOff() end)
     end
 
     hs.hotkey.bind(
       {"ctrl", "alt", "cmd"},
       "l",
-      function () 
+      function ()
         logger.i('window id: ' .. tostring(frontmostWindow():id()))
         logger.i('windows: ' .. hs.inspect(self._originalPositionStore['fullscreen']))
       end)
@@ -627,6 +626,7 @@ function obj:bindHotkeys(mapping)
 
 --- MiroWindowsManager:init()
 --- Method
+--- Currently does nothing (implemented so that treating this Spoon like others won't cause errors).
 function obj:init()
   -- void (but it could be used to initialize the module)
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miro's windows manager
 
-With this script you will be able to move the window in halves and in corners using your keyboard and mainly using arrows. You would also be able to resize them by thirds, quarters, or halves.
+With this Hammerspoon Spoon you will be able to move windows in halves and in corners using your keyboard, mainly using arrows. You will also be able to resize them by thirds, quarters, or halves.
 
 Other projects (e.g. Spectacle) move windows in halves using arrows, and in corners using other counterintuitive shortcuts, like letters, which makes things confusing.
 
@@ -12,19 +12,20 @@ This script needs Hammerspoon in order to work.
 
  - Extract the zip file, containing `MiroWindowsManager.spoon` in `~/.hammerspoon/Spoons`
  - Now you need to configure Hammerspoon in order to load this spoon in `~/.hammerspoon/Spoons/MiroWindowsManager.spoon` adding the following snippet of code in your `init.lua` file:
-```
-local hyper = {"ctrl", "alt", "cmd"}
-
+``` lua
 hs.loadSpoon("MiroWindowsManager")
-
-hs.window.animationDuration = 0.3
+local hyper = {"ctrl", "alt", "cmd"}
 spoon.MiroWindowsManager:bindHotkeys({
-  up = {hyper, "up"},
-  right = {hyper, "right"},
-  down = {hyper, "down"},
-  left = {hyper, "left"},
-  fullscreen = {hyper, "f"}
+  up          = {hyper, "up"},
+  down        = {hyper, "down"},
+  left        = {hyper, "left"},
+  right       = {hyper, "right"},
+  fullscreen  = {hyper, "f"},
+  center      = {hyper, "c"},
+  move        = {hyper, "v"},
+  resize      = {hyper, "d" }
 })
+hs.window.animationDuration = 0.3
 ```
 
 ## Shortcuts
@@ -33,7 +34,7 @@ In the snippet above configure Miro'w Windows Manager in the following way:
 
 ### Hyper key
 
- The hyper key is defined as `ctrl` + `alt` + `cmd`. This means that each shortcut will start by pressing these three keys. If you consider this too verbose for your personal keyboard interactions, you can also change it, for example replacing it with an unused key (e.g. caps lock key) with [Karabiner](https://pqrs.org/osx/karabiner/) and [Seil](https://pqrs.org/osx/karabiner/seil.html.en) to act as hyper key.
+ The hyper key is defined as `ctrl` + `alt` + `cmd`. This means that each shortcut will start by pressing these three keys. If you consider this too verbose for your personal keyboard interactions, you can also change it, for example replacing it with an unused modifier key (e.g. caps lock key with [Karabiner Elements](https://pqrs.org/osx/karabiner/)).
 
 ### Move in halves
 
@@ -69,6 +70,18 @@ These are useful in case the window is in one of the corners.
 Note that in case the window is resized to be a half of the screen, you can also use `hyper` + `up` + `down` (or `hyper` + `right` + `left`) to resize the window full screen.
 
 As the other shortcuts, `hyper` + `f` can be pressed multiple times to obtain a centered window of three fourth and one half of height and width. This behaviour can be customized.
+
+### Center window
+
+ - `hyper` + `c`: center window without changing its size
+
+### Move Mode
+
+ - Press and hold `hyper` + `v`, then tap the move keys to move the window in increments of 5% of the screen size
+
+### Resize Mode
+
+ - Press and hold `hyper` + `d`, then tap the move keys to resize the window in increments of 5% of the screen size.
 
 ## Animations
 


### PR DESCRIPTION
Bugfix:
* don't force windows from higher or lefter screens onto the primary screen when resizing

Refactoring:
* use `hs.hotkey.modal` for move and resize modals
* some code & documentation cleanup

Change:
* support the same resize to full-width/height behaviour when pressing opposite directions simultaneously in Move and Resize Modes

@miromannino ,
Thank you again for your stellar work on this Spoon. I like your keyboard interface for Move & Resize Modes much more than I liked the one I created in my last pull request.

If you don't like the addition of jumping to full width/height after tapping opposite directions in Move & Resize Modes, remove `; growFullyModals[move]:enter()` from line 564, `; growFullyModals[mapR[resize]]:enter()` from line 583, then remove lines 584, 580 and 565.